### PR TITLE
Fix Spotify playback/authentication (token auth)

### DIFF
--- a/mopidy/Dockerfile
+++ b/mopidy/Dockerfile
@@ -2,7 +2,8 @@ FROM debian:12-slim
 LABEL Author="Rogger Fabri"
 
 ARG ARCH=amd64
-ARG GST_PLUGIN_SPOTIFY_VERSION=0.13.1-1
+ARG GST_PLUGIN_SPOTIFY_VERSION_PATH=0.14.0-alpha.1-1
+ARG GST_PLUGIN_SPOTIFY_VERSION_FILE=0.14.0.alpha.1-1
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PIP_NO_CACHE_DIR=1
@@ -21,17 +22,17 @@ RUN apt update && apt upgrade -y \
     Mopidy-Mobile \
     Mopidy-MPD \
     Mopidy-Scrobbler \
-    Mopidy-Spotify==5.0.0a2 \
+    Mopidy-Spotify==5.0.0a3 \
     Mopidy-TuneIn \
  && apt purge --auto-remove -y \
     gcc \
  && apt clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* ~/.cache /root/.cache
 
-RUN curl -L -o gst-plugin-spotify_${GST_PLUGIN_SPOTIFY_VERSION}_${ARCH}.deb https://github.com/kingosticks/gst-plugins-rs-build/releases/download/gst-plugin-spotify_${GST_PLUGIN_SPOTIFY_VERSION}/gst-plugin-spotify_${GST_PLUGIN_SPOTIFY_VERSION}_${ARCH}.deb \
- && dpkg -i gst-plugin-spotify_${GST_PLUGIN_SPOTIFY_VERSION}_${ARCH}.deb \
+RUN curl -L -o gst-plugin-spotify_${GST_PLUGIN_SPOTIFY_VERSION_FILE}_${ARCH}.deb https://github.com/kingosticks/gst-plugins-rs-build/releases/download/gst-plugin-spotify_${GST_PLUGIN_SPOTIFY_VERSION_PATH}/gst-plugin-spotify_${GST_PLUGIN_SPOTIFY_VERSION_FILE}_${ARCH}.deb \
+ && dpkg -i gst-plugin-spotify_${GST_PLUGIN_SPOTIFY_VERSION_FILE}_${ARCH}.deb \
   ; apt update && apt -f install -y \
- && rm gst-plugin-spotify_${GST_PLUGIN_SPOTIFY_VERSION}_${ARCH}.deb \
+ && rm gst-plugin-spotify_${GST_PLUGIN_SPOTIFY_VERSION_FILE}_${ARCH}.deb \
  && curl -L -o libshout3_2.4.1-2_${ARCH}.deb http://ftp.de.debian.org/debian/pool/main/libs/libshout/libshout3_2.4.1-2_${ARCH}.deb \
  && dpkg -i libshout3_2.4.1-2_${ARCH}.deb \
   ; apt update && apt -f install -y \


### PR DESCRIPTION
I did a fresh install (with icecast) and couldn't get any tracks from Spotify to play. Local files worked nicely. This is somewhat similar to the problem described in #52.

In the logs:
`mopidy.audio.gst`
`GStreamer error: Could not get/set settings from/on resource.`

By setting the environment variable `GST_DEBUG=3` in the mopidy container, you can get some more detailed information, including this line:
`failed to start: Login failed with reason: Bad credentials`

### Upgrading Mopidy-Spotify and `gst-plugin-spotify`

The reason for this seems to be that auth using username and password is no longer allowed by Spotify. To fix this, I had to upgrade Mopidy-Spotify from version `5.0.0a2` to `5.0.0a3`. This version also [requires a newer forked version](https://github.com/mopidy/mopidy-spotify#dependencies) of `gst-plugin-spotify`. I've updated the Dockerfile accordingly.

To check Mopidy-Spotify version:
`sudo docker exec -it mopidy-icecast pip list | grep Spotify`

To check if `gst-plugin-spotify` (providing the spotify uri handler) is installed correctly:
`sudo docker exec -it mopidy-icecast gst-inspect-1.0 spotifyaudiosrc | grep Version | awk '{print $2}'`

### Bonus observation regarding libshout3

Btw, the issue in libshout3 seems to have been fixed in v2.4.6 according to [this issue](https://gitlab.xiph.org/xiph/icecast-libshout/-/issues/2325). When I run the following command, I saw that version is already installed (instead of `2.4.1-2` specified in Dockerfile). It seems like it got upgraded immediately, likely by the next command.
 `sudo docker exec -it mopidy-icecast apt list | grep libshout` 

