### PR TITLE
feat: extract librespot into a standalone container

### DIFF
--- a/.github/workflows/librespot-amd64.yaml
+++ b/.github/workflows/librespot-amd64.yaml
@@ -1,0 +1,44 @@
+name: librespot-amd64
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - "master"
+    paths:
+      - "librespot/**"
+  push:
+    branches:
+      - "master"
+    paths:
+      - "librespot/**"
+  repository_dispatch:
+    types: [raspotify-update-version]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and Push
+        uses: docker/build-push-action@v6
+        with:
+          push: ${{ github.event_name != 'pull_request' }}
+          context: "${{ github.server_url }}/${{ github.repository }}.git#${{ github.ref }}:librespot"
+          tags: |
+            ${{ secrets.DOCKERHUB_SLUG }}/librespot:amd64-latest
+            ${{ secrets.DOCKERHUB_SLUG }}/librespot:amd64-${{github.run_number}}
+          build-args: |
+            target_arch=amd64
+          provenance: true
+          sbom: true
+          cache-from: type=gha,scope=librespot-amd64
+          cache-to: type=gha,mode=max,scope=librespot-amd64

--- a/.github/workflows/librespot-arm64v8.yaml
+++ b/.github/workflows/librespot-arm64v8.yaml
@@ -1,0 +1,45 @@
+name: librespot-arm64v8
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - "master"
+    paths:
+      - "librespot/**"
+  push:
+    branches:
+      - "master"
+    paths:
+      - "librespot/**"
+  repository_dispatch:
+    types: [raspotify-update-version]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and Push
+        uses: docker/build-push-action@v6
+        with:
+          push: ${{ github.event_name != 'pull_request' }}
+          context: "${{ github.server_url }}/${{ github.repository }}.git#${{ github.ref }}:librespot"
+          tags: |
+            ${{ secrets.DOCKERHUB_SLUG }}/librespot:arm64v8-latest
+            ${{ secrets.DOCKERHUB_SLUG }}/librespot:arm64v8-${{github.run_number}}
+          platforms: linux/arm64
+          build-args: |
+            target_arch=arm64
+          provenance: true
+          sbom: true
+          cache-from: type=gha,scope=librespot-arm64
+          cache-to: type=gha,mode=max,scope=librespot-arm64

--- a/.github/workflows/raspotify-update-version.yaml
+++ b/.github/workflows/raspotify-update-version.yaml
@@ -49,15 +49,7 @@ jobs:
 
             Automated update triggered by the scheduled workflow.
 
-      - name: Trigger snapserver-amd64 Build
-        if: steps.diff.outputs.changed == 'true'
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.repository }}
-          event-type: raspotify-update-version
-
-      - name: Trigger snapserver-arm64v8 Build
+      - name: Trigger librespot Builds
         if: steps.diff.outputs.changed == 'true'
         uses: peter-evans/repository-dispatch@v3
         with:

--- a/README.md
+++ b/README.md
@@ -61,9 +61,17 @@ The system uses Iris as the primary web frontend, offering a beautiful and respo
 Snapcast provides multi-room client-server audio playback with perfect synchronization between all clients. Features include:
 
 - **Time-Synchronized Playback**: All clients play audio in perfect sync
-- **Multiple Stream Support**: Includes Mopidy and Spotify Connect streams
+- **Multiple Stream Support**: Includes Mopidy, Spotify Connect, and AirPlay (Shairport-Sync) streams
 - **Various Client Options**: Desktop, mobile, and web clients available
-- **Built-in Spotify Connect**: Stream directly from Spotify to Snapcast via Raspotify
+
+### Librespot (Spotify Connect)
+
+A standalone [librespot](https://github.com/librespot-org/librespot) container (built from the Raspotify packages) provides the Spotify Connect endpoint:
+
+- **Runs on the host network** so zeroconf/mDNS discovery works on the LAN — phones can always find the device, even if the Spotify cloud session drops
+- **Feeds audio to Snapserver through a named pipe** (`/tmp/librespot-audio` in the shared pipes volume), like the Shairport-Sync integration
+- **Self-healing**: an in-container watchdog probes librespot's zeroconf endpoint and restarts the container automatically if librespot wedges
+- **Metadata bridge**: player events flow through `/tmp/librespot-metadata` to a Snapcast controlscript (`meta_librespot.py`), so track title/artist/cover show up in Snapweb
 
 ### Stream Manager
 
@@ -97,7 +105,7 @@ The Mopidy configuration for the Icecast setup is in `mopidy-icesnap/mopidy/mopi
 - **[spotify]**: Add your `client_id` and `client_secret` from [Mopidy Spotify Authentication](https://mopidy.com/ext/spotify/#authentication)
 - **[scrobbler]**: Optional Last.fm scrobbler configuration
 
-For the Snapcast setup, review the `snapserver.conf` file and update Spotify credentials if needed.
+For the Snapcast setup, review the `snapserver.conf` file. Spotify Connect needs no credentials in config: the librespot container is discovered via zeroconf and authenticates when you select it in the Spotify app (credentials are then cached in its cache volume).
 
 ### Access Points
 
@@ -138,7 +146,12 @@ Pre-built Docker images are available at: [https://hub.docker.com/u/rfabri](http
    - Double-check client ID and secret
    - Verify Spotify account has an active subscription
 
-3. **Icecast stream not accessible**
+3. **Spotify Connect device not visible**
+   - Check `docker logs librespot` for zeroconf/session errors
+   - The librespot container must run with host networking; verify the zeroconf port (default 39799) is reachable and mDNS (UDP 5353) isn't blocked by a firewall
+   - The container self-restarts if librespot hangs — check `docker inspect librespot --format '{{.RestartCount}}'`
+
+4. **Icecast stream not accessible**
    - Check if the Icecast container is running
    - Verify port forwarding if accessing from outside the network
 
@@ -148,6 +161,7 @@ Access container logs for troubleshooting:
 docker logs mopidy
 docker logs icecast
 docker logs snapserver
+docker logs librespot
 ```
 
 ## License

--- a/librespot/Dockerfile
+++ b/librespot/Dockerfile
@@ -10,6 +10,7 @@ ENV DEVICE_NAME=Snapcast \
     BITRATE=320 \
     INITIAL_VOLUME=100 \
     ZEROCONF_PORT=39799 \
+    ZEROCONF_BACKEND=avahi \
     CACHE_DIR=/var/cache/librespot \
     PIPE_PATH=/tmp/librespot-audio \
     METADATA_PIPE=/tmp/librespot-metadata \

--- a/librespot/Dockerfile
+++ b/librespot/Dockerfile
@@ -1,0 +1,43 @@
+FROM debian:12-slim
+LABEL Author="Rogger Fabri"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+ARG raspotify_version=0.48.1
+ARG target_arch=arm64
+
+ENV DEVICE_NAME=Snapcast \
+    BITRATE=320 \
+    INITIAL_VOLUME=100 \
+    ZEROCONF_PORT=39799 \
+    CACHE_DIR=/var/cache/librespot \
+    PIPE_PATH=/tmp/librespot-audio \
+    METADATA_PIPE=/tmp/librespot-metadata \
+    WATCHDOG_INTERVAL=30 \
+    WATCHDOG_FAILURES=4 \
+    LIBRESPOT_EXTRA_ARGS=
+
+RUN apt update && apt upgrade -y \
+    curl \
+    dumb-init \
+    jq \
+ && RASPOTIFY_URL=$(curl -s https://api.github.com/repos/dtcooper/raspotify/releases/tags/${raspotify_version} | jq -r '.assets[] | select(.name | contains("raspotify") and contains("'${target_arch}'")) | .browser_download_url' | head -1) \
+ && curl -sLO "${RASPOTIFY_URL}" \
+ && dpkg -i raspotify_*_${target_arch}.deb \
+  ; apt update && apt -f install -y \
+ && rm raspotify_*_${target_arch}.deb \
+ && apt clean \
+ && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* ~/.cache /root/.cache
+
+RUN /usr/bin/librespot --version
+
+COPY start.sh /start.sh
+COPY onevent.sh /onevent.sh
+
+EXPOSE 39799
+
+ENTRYPOINT ["dumb-init", "--"]
+CMD ["/start.sh"]
+
+HEALTHCHECK --interval=60s --timeout=10s --start-period=120s --retries=3 \
+    CMD curl --connect-timeout 5 --silent --show-error --fail "http://localhost:${ZEROCONF_PORT}/?action=getInfo" || exit 1

--- a/librespot/onevent.sh
+++ b/librespot/onevent.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# Called by librespot for every player event; forwards the ones relevant to
+# metadata/playback state as a JSON line into the metadata FIFO, where the
+# snapserver-side controlscript (meta_librespot.py) picks them up.
+#
+# librespot waits for this script to exit before dispatching the next event,
+# so it must never block: the FIFO write is wrapped in a short timeout and
+# the event is dropped when nobody is reading.
+
+case "$PLAYER_EVENT" in
+    track_changed|playing|paused|stopped) ;;
+    *) exit 0 ;;
+esac
+
+# ARTISTS and COVERS arrive newline-separated; jq turns them into arrays and
+# handles all JSON escaping of track names.
+json=$(jq -cn \
+    --arg event "$PLAYER_EVENT" \
+    --arg name "${NAME:-}" \
+    --arg artists "${ARTISTS:-}" \
+    --arg album "${ALBUM:-}" \
+    --arg covers "${COVERS:-}" \
+    --arg duration_ms "${DURATION_MS:-}" \
+    --arg track_id "${TRACK_ID:-}" \
+    --arg position_ms "${POSITION_MS:-}" \
+    '{
+        event: $event,
+        name: $name,
+        artists: ($artists | split("\n") | map(select(. != ""))),
+        album: $album,
+        covers: ($covers | split("\n") | map(select(. != ""))),
+        duration_ms: $duration_ms,
+        track_id: $track_id,
+        position_ms: $position_ms
+    }')
+
+printf '%s\n' "$json" | timeout 2 sh -c 'cat > "$METADATA_PIPE"' 2>/dev/null || true

--- a/librespot/start.sh
+++ b/librespot/start.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/dumb-init /bin/sh
+
+env
+
+set -x
+
+# librespot's pipe backend opens its output with create=true: if the FIFO is
+# missing it silently writes a growing regular file instead, so both pipes
+# must exist as FIFOs before playback starts.
+for p in "$PIPE_PATH" "$METADATA_PIPE"; do
+    if [ ! -p "$p" ]; then
+        rm -f "$p"
+        mkfifo "$p"
+    fi
+    chmod 777 "$p"
+done
+
+mkdir -p "$CACHE_DIR"
+
+librespot \
+    --name "$DEVICE_NAME" \
+    --backend pipe \
+    --device "$PIPE_PATH" \
+    --format S16 \
+    --bitrate "$BITRATE" \
+    --initial-volume "$INITIAL_VOLUME" \
+    --zeroconf-port "$ZEROCONF_PORT" \
+    --cache "$CACHE_DIR" \
+    --disable-audio-cache \
+    --onevent /onevent.sh \
+    $LIBRESPOT_EXTRA_ARGS &
+LIBRESPOT_PID=$!
+
+# librespot can wedge with its process alive but its Spotify session dead, in
+# which case it never recovers on its own. The zeroconf HTTP endpoint doubles
+# as a liveness probe: on sustained failure, kill librespot so the container
+# exits and docker's restart policy brings it back fresh. TERM first, KILL
+# after a grace period because a wedged process may never handle TERM.
+(
+    fails=0
+    while kill -0 "$LIBRESPOT_PID" 2>/dev/null; do
+        sleep "$WATCHDOG_INTERVAL"
+        if curl --connect-timeout 5 --max-time 8 --silent --fail \
+                "http://localhost:${ZEROCONF_PORT}/?action=getInfo" >/dev/null; then
+            fails=0
+        else
+            fails=$((fails + 1))
+            echo "watchdog: getInfo probe failed (${fails}/${WATCHDOG_FAILURES})"
+            if [ "$fails" -ge "$WATCHDOG_FAILURES" ]; then
+                echo "watchdog: librespot unresponsive, terminating"
+                kill -TERM "$LIBRESPOT_PID" 2>/dev/null
+                sleep 10
+                kill -KILL "$LIBRESPOT_PID" 2>/dev/null
+                break
+            fi
+        fi
+    done
+) &
+
+wait "$LIBRESPOT_PID"
+EXIT_CODE=$?
+echo "librespot exited with code ${EXIT_CODE}"
+exit "$EXIT_CODE"

--- a/librespot/start.sh
+++ b/librespot/start.sh
@@ -25,6 +25,7 @@ librespot \
     --bitrate "$BITRATE" \
     --initial-volume "$INITIAL_VOLUME" \
     --zeroconf-port "$ZEROCONF_PORT" \
+    --zeroconf-backend "$ZEROCONF_BACKEND" \
     --cache "$CACHE_DIR" \
     --disable-audio-cache \
     --onevent /onevent.sh \

--- a/mopidy-snapserver/docker-compose.yaml
+++ b/mopidy-snapserver/docker-compose.yaml
@@ -21,9 +21,15 @@ services:
       - TZ=<YOUR_TIMEZONE>
       - DEVICE_NAME=Snapcast
       - ZEROCONF_PORT=39799
+      # Default backend announces through the host's avahi daemon (socket
+      # mounts below). On hosts without avahi, set ZEROCONF_BACKEND=libmdns
+      # and drop the two socket mounts.
+      - ZEROCONF_BACKEND=avahi
     volumes:
       - shared_pipes:/tmp
       - <HOST_PATH>/librespot:/var/cache/librespot
+      - /var/run/avahi-daemon:/var/run/avahi-daemon
+      - /var/run/dbus:/var/run/dbus
 
   shairport-sync:
     container_name: shairport-sync

--- a/mopidy-snapserver/docker-compose.yaml
+++ b/mopidy-snapserver/docker-compose.yaml
@@ -1,6 +1,41 @@
-version: "2.4"
-
 services:
+  init-pipes:
+    container_name: init-pipes
+    image: alpine:3
+    command: >
+      sh -c "for p in /tmp/snapfifo /tmp/shairport-sync-audio /tmp/shairport-sync-metadata /tmp/librespot-audio /tmp/librespot-metadata;
+             do [ -p $$p ] || { rm -f $$p; mkfifo $$p; }; chmod 777 $$p; done"
+    volumes:
+      - shared_pipes:/tmp
+
+  librespot:
+    container_name: librespot
+    image: rfabri/librespot:arm64v8-latest # amd64-latest on x86-64
+    # Host networking so Spotify Connect zeroconf/mDNS discovery works on the
+    # LAN; the discovery port is fixed via ZEROCONF_PORT.
+    network_mode: host
+    restart: always
+    depends_on:
+      - init-pipes
+    environment:
+      - TZ=<YOUR_TIMEZONE>
+      - DEVICE_NAME=Snapcast
+      - ZEROCONF_PORT=39799
+    volumes:
+      - shared_pipes:/tmp
+      - <HOST_PATH>/librespot:/var/cache/librespot
+
+  shairport-sync:
+    container_name: shairport-sync
+    image: mikebrady/shairport-sync
+    network_mode: host
+    restart: always
+    depends_on:
+      - init-pipes
+    volumes:
+      - <HOST_PATH>/shairport-sync/shairport-sync.conf:/etc/shairport-sync.conf
+      - shared_pipes:/tmp
+
   snapserver:
     container_name: snapserver
     image: rfabri/snapserver:arm64v8-latest
@@ -10,10 +45,11 @@ services:
       - "1704:1704"
       - "1705:1705"
       - "1780:1780"
+    depends_on:
+      - init-pipes
     volumes:
-      - ~/snapserver/:/root/.config/snapserver/
-      - ~/snapserver/snapserver.conf:/etc/snapserver.conf
-      - /tmp:/tmp
+      - <HOST_PATH>/snapserver/snapserver.conf:/etc/snapserver.conf
+      - shared_pipes:/tmp
       - /var/run/avahi-daemon:/var/run/avahi-daemon
       - /var/run/dbus:/var/run/dbus
 
@@ -27,17 +63,21 @@ services:
       - "5555:5555/udp"
     depends_on:
       - snapserver
+      - init-pipes
     volumes:
-      - ~/mopidy-icesnap/mopidy/mopidy-snapserver.conf:/mopidy/mopidy.conf
-      - ~/mopidy-snapserver/:/mopidy
-      - /tmp:/tmp
+      - <HOST_PATH>/mopidy-icesnap/mopidy/mopidy-snapserver.conf:/mopidy/mopidy.conf
+      - <HOST_PATH>/mopidy-snapserver/:/mopidy
+      - shared_pipes:/tmp
 
   stream-manager:
     container_name: stream-manager
     image: rfabri/stream-manager:arm64v8-latest
-    environment:
-      -  SNAPSERVER_IP=<SNAPSERVER_IP>
-      -  SNAPSERVER_PORT=<SNAPSERVER_PORT>
     restart: unless-stopped
+    environment:
+      - SNAPSERVER_IP=snapserver
+      - SNAPSERVER_PORT=1705
     depends_on:
       - snapserver
+
+volumes:
+  shared_pipes:

--- a/snapserver/Dockerfile
+++ b/snapserver/Dockerfile
@@ -4,30 +4,26 @@ LABEL Author="Rogger Fabri"
 ENV DEBIAN_FRONTEND=noninteractive
 
 ARG snapcast_version=0.35.0
-ARG raspotify_version=0.48.1
 ARG target_arch=arm64
 ARG dist=bookworm
 
 RUN apt update && apt upgrade -y \
     curl \
     dumb-init \
-    jq \
+    python3-minimal \
  && curl -sLO https://github.com/badaix/snapcast/releases/download/v${snapcast_version}/snapserver_${snapcast_version}-1_${target_arch}_${dist}.deb \
  && dpkg -i snapserver_${snapcast_version}-1_${target_arch}_${dist}.deb \
   ; apt update && apt -f install -y \
  && rm snapserver_${snapcast_version}-1_${target_arch}_${dist}.deb \
- && RASPOTIFY_URL=$(curl -s https://api.github.com/repos/dtcooper/raspotify/releases/tags/${raspotify_version} | jq -r '.assets[] | select(.name | contains("raspotify") and contains("'${target_arch}'")) | .browser_download_url' | head -1) \
- && curl -sLO "${RASPOTIFY_URL}" \
- && dpkg -i raspotify_*_${target_arch}.deb \
-  ; apt update && apt -f install -y \
- && rm raspotify_*_${target_arch}.deb \
  && apt purge --auto-remove -y \
     gcc \
  && apt clean \
  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* ~/.cache /root/.cache
 
 RUN /usr/bin/snapserver -v
-RUN dpkg -l | grep -i raspotify
+
+COPY meta_librespot.py /usr/share/snapserver/plug-ins/meta_librespot.py
+RUN chmod +x /usr/share/snapserver/plug-ins/meta_librespot.py
 
 EXPOSE 1704 1705 1780
 

--- a/snapserver/meta_librespot.py
+++ b/snapserver/meta_librespot.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Snapcast stream-plugin controlscript bridging librespot player events.
+
+librespot runs standalone (see the librespot/ image) with --onevent, whose
+hook serializes player events as JSON lines into a FIFO shared through the
+compose 'shared_pipes' volume. This script tails that FIFO and forwards
+playback state and track metadata to snapserver over the stream-plugin
+JSON-RPC protocol on stdout/stdin.
+
+librespot has no external control API, so every can* capability is reported
+false and control requests are rejected; Snapweb shows metadata without
+playback buttons.
+"""
+
+import argparse
+import json
+import sys
+import threading
+import time
+
+DEFAULT_METADATA_PIPE = "/tmp/librespot-metadata"
+
+state_lock = threading.Lock()
+properties = {
+    "playbackStatus": "stopped",
+    "loopStatus": "none",
+    "shuffle": False,
+    "mute": False,
+    "canControl": False,
+    "canPlay": False,
+    "canPause": False,
+    "canSeek": False,
+    "canGoNext": False,
+    "canGoPrevious": False,
+    "metadata": {},
+}
+
+
+def send(message):
+    sys.stdout.write(json.dumps(message) + "\n")
+    sys.stdout.flush()
+
+
+def log(severity, message):
+    send({
+        "jsonrpc": "2.0",
+        "method": "Plugin.Stream.Log",
+        "params": {"severity": severity, "message": message},
+    })
+
+
+def notify_properties():
+    with state_lock:
+        params = dict(properties)
+    send({
+        "jsonrpc": "2.0",
+        "method": "Plugin.Stream.Player.Properties",
+        "params": params,
+    })
+
+
+def ms_to_seconds(value):
+    try:
+        return int(value) / 1000.0
+    except (TypeError, ValueError):
+        return None
+
+
+def handle_event(event):
+    kind = event.get("event")
+    with state_lock:
+        if kind == "track_changed":
+            metadata = {}
+            if event.get("name"):
+                metadata["title"] = event["name"]
+            if event.get("artists"):
+                metadata["artist"] = event["artists"]
+            if event.get("album"):
+                metadata["album"] = event["album"]
+            if event.get("covers"):
+                metadata["artUrl"] = event["covers"][0]
+            if event.get("track_id"):
+                metadata["trackId"] = event["track_id"]
+            duration = ms_to_seconds(event.get("duration_ms"))
+            if duration is not None:
+                metadata["duration"] = duration
+            properties["metadata"] = metadata
+        elif kind in ("playing", "paused", "stopped"):
+            properties["playbackStatus"] = kind
+            if kind == "stopped":
+                properties["metadata"] = {}
+        else:
+            return
+        position = ms_to_seconds(event.get("position_ms"))
+        if position is not None:
+            properties["position"] = position
+        else:
+            properties.pop("position", None)
+    notify_properties()
+
+
+def fifo_reader(path):
+    while True:
+        try:
+            # Opening the FIFO blocks until a writer connects; each onevent
+            # write closes the pipe again, so reopen on EOF forever.
+            with open(path, "r", encoding="utf-8", errors="replace") as fifo:
+                for line in fifo:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        handle_event(json.loads(line))
+                    except (json.JSONDecodeError, TypeError) as exc:
+                        log("Error", "bad metadata event: %s" % exc)
+        except OSError as exc:
+            log("Error", "metadata pipe %s unavailable (%s), retrying" % (path, exc))
+            time.sleep(5)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    # Passed automatically by snapserver to every controlscript.
+    parser.add_argument("--stream", default="")
+    parser.add_argument("--snapcast-port", default="")
+    parser.add_argument("--snapcast-host", default="")
+    # Overridable via controlscriptparams in the stream URI.
+    parser.add_argument("--metadata-pipe", default=DEFAULT_METADATA_PIPE)
+    args, _ = parser.parse_known_args()
+
+    threading.Thread(target=fifo_reader, args=(args.metadata_pipe,), daemon=True).start()
+
+    send({"jsonrpc": "2.0", "method": "Plugin.Stream.Ready"})
+
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            request = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        request_id = request.get("id")
+        method = request.get("method", "")
+        if method == "Plugin.Stream.Player.GetProperties":
+            with state_lock:
+                result = dict(properties)
+            send({"jsonrpc": "2.0", "id": request_id, "result": result})
+        elif method in ("Plugin.Stream.Player.Control", "Plugin.Stream.Player.SetProperty"):
+            send({
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "error": {"code": -32601, "message": "Stream cannot be controlled"},
+            })
+        elif request_id is not None:
+            send({
+                "jsonrpc": "2.0",
+                "id": request_id,
+                "error": {"code": -32601, "message": "Method not found"},
+            })
+
+
+if __name__ == "__main__":
+    main()

--- a/snapserver/snapserver.conf
+++ b/snapserver/snapserver.conf
@@ -1,6 +1,9 @@
 [stream]
 stream = pipe:////tmp/snapfifo?name=Mopidy
-stream = spotify:///librespot?name=Spotify&devicename=Snapcast&bitrate=320&volume=100&username=SPOTIFY_USERNAME&password=SPOTIFY_PASSWORD
+stream = pipe:////tmp/librespot-audio?name=Spotify&sampleformat=44100:16:2&mode=read&controlscript=meta_librespot.py
+# Legacy embedded-librespot source (librespot now runs in its own container,
+# see the librespot/ image and docker-compose):
+# stream = spotify:///librespot?name=Spotify&devicename=Snapcast&bitrate=320&volume=100
 
 [http]
 enabled = true


### PR DESCRIPTION
## Why

The Spotify Connect device ("Snapcast") intermittently vanishes until `docker restart snapserver`. Root cause (confirmed from logs + snapcast source):

- librespot 0.8.0's cloud dealer websocket occasionally hangs silently
- snapserver's `wd_timeout` watchdog then kills librespot, but snapcast's `ProcessStream::onTimeout` **never respawns it**
- zeroconf/mDNS LAN discovery can't act as fallback: snapserver runs on a bridge network and librespot's random discovery port is unpublished

## What

- **New `librespot/` image**: standalone librespot (from raspotify debs) designed for `network_mode: host`
  - audio → `/tmp/librespot-audio` FIFO (shared_pipes volume), same pattern as shairport-sync
  - fixed zeroconf port (39799) + healthcheck on the discovery endpoint
  - in-container watchdog kills librespot on sustained probe failure → container exits → `restart: always` recovers, without touching the other streams
  - `onevent.sh` forwards player events as JSON into `/tmp/librespot-metadata`
- **snapserver**: raspotify removed; new `meta_librespot.py` controlscript (snapcast stream-plugin protocol) bridges the metadata FIFO so Snapweb keeps track title/artist/cover; Spotify stream becomes a `pipe://` source
- **CI**: new `librespot-{amd64,arm64v8}` workflows; they listen for the `raspotify-update-version` dispatch (previously fired with no listeners); bump workflow's duplicate dispatch steps consolidated
- **Compose template + README** modernized to match

## Verification

- `meta_librespot.py` protocol + event mapping smoke-tested locally (Ready/GetProperties/Control-reject, track_changed→metadata mapping)
- `onevent.sh` jq serialization tested incl. quotes/apostrophes and multi-value artists/covers
- arm64 image build-tested on the target Raspberry Pi from this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)