### PR TITLE
ci(github): dispatch snapcast-update-version once instead of four times

### DIFF
--- a/.github/workflows/snapcast-update-version.yaml
+++ b/.github/workflows/snapcast-update-version.yaml
@@ -49,31 +49,9 @@ jobs:
 
             Automated update triggered by the scheduled workflow.
 
-      - name: Trigger snapclient-amd64 Build
-        if: steps.diff.outputs.changed == 'true'
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.repository }}
-          event-type: snapcast-update-version
-
-      - name: Trigger snapclient-arm64v8 Build
-        if: steps.diff.outputs.changed == 'true'
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.repository }}
-          event-type: snapcast-update-version
-
-      - name: Trigger snapserver-amd64 Build
-        if: steps.diff.outputs.changed == 'true'
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.repository }}
-          event-type: snapcast-update-version
-
-      - name: Trigger snapserver-arm64v8 Build
+      # A single dispatch of this event-type triggers every workflow listening
+      # for it (snapclient + snapserver, both arches).
+      - name: Trigger snapclient and snapserver Builds
         if: steps.diff.outputs.changed == 'true'
         uses: peter-evans/repository-dispatch@v3
         with:


### PR DESCRIPTION
`repository_dispatch` fans out to **every** workflow listening for the event-type, so the four per-image dispatch steps quadruple-built the snapclient and snapserver images (both arches) on every snapcast version bump — 16 builds where 4 suffice.

One dispatch triggers all four listening workflows. Same fix as the raspotify flow in #61.

🤖 Generated with [Claude Code](https://claude.com/claude-code)