### PR TITLE
fix(librespot): detect dealer-websocket wedge in watchdog and healthcheck

### DIFF
--- a/librespot/Dockerfile
+++ b/librespot/Dockerfile
@@ -16,6 +16,7 @@ ENV DEVICE_NAME=Snapcast \
     METADATA_PIPE=/tmp/librespot-metadata \
     WATCHDOG_INTERVAL=30 \
     WATCHDOG_FAILURES=4 \
+    WATCHDOG_CLOUD_CHECK=on \
     LIBRESPOT_EXTRA_ARGS=
 
 RUN apt update && apt upgrade -y \
@@ -34,6 +35,7 @@ RUN /usr/bin/librespot --version
 
 COPY start.sh /start.sh
 COPY onevent.sh /onevent.sh
+COPY probe.sh /probe.sh
 
 EXPOSE 39799
 
@@ -41,4 +43,4 @@ ENTRYPOINT ["dumb-init", "--"]
 CMD ["/start.sh"]
 
 HEALTHCHECK --interval=60s --timeout=10s --start-period=120s --retries=3 \
-    CMD curl --connect-timeout 5 --silent --show-error --fail "http://localhost:${ZEROCONF_PORT}/?action=getInfo" || exit 1
+    CMD /probe.sh || exit 1

--- a/librespot/probe.sh
+++ b/librespot/probe.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+
+# Liveness probe for librespot, shared by the container HEALTHCHECK and the
+# start.sh watchdog. Exit 0 = healthy.
+#
+# Check 1: the zeroconf HTTP endpoint answers (LAN discovery half).
+#
+# Check 2: the Spotify cloud session is alive. librespot can wedge with the
+# AP connection (remote port 4070) still established but the dealer
+# websocket (remote port 443) gone — it then logs nothing, never reconnects,
+# and the device silently disappears from Spotify Connect while zeroconf
+# still answers. A healthy session keeps the dealer websocket open at all
+# times, so the sustained absence of any ESTABLISHED librespot socket with
+# remote port 443 means the session is dead. The check self-arms via a
+# marker file the first time such a connection is seen, so credential-less
+# deployments that idle without a session are not restart-looped.
+
+curl --connect-timeout 5 --max-time 8 --silent --fail \
+    "http://localhost:${ZEROCONF_PORT}/?action=getInfo" >/dev/null || {
+    echo "probe: zeroconf endpoint not answering"
+    exit 1
+}
+
+[ "$WATCHDOG_CLOUD_CHECK" = "off" ] && exit 0
+
+pid=
+for p in /proc/[0-9]*; do
+    if [ "$(cat "$p/comm" 2>/dev/null)" = "librespot" ]; then
+        pid=${p#/proc/}
+        break
+    fi
+done
+if [ -z "$pid" ]; then
+    echo "probe: librespot process not found"
+    exit 1
+fi
+
+# The container runs with host networking, so /proc/net/tcp* lists the whole
+# host: filter to sockets whose inode belongs to the librespot process.
+inodes=$(for fd in /proc/"$pid"/fd/*; do readlink "$fd"; done 2>/dev/null \
+    | sed -n 's/^socket:\[\(.*\)\]$/\1/p' | tr '\n' ' ')
+
+if awk -v inodes="$inodes" '
+    BEGIN { n = split(inodes, a, " "); for (i = 1; i <= n; i++) set[a[i]] = 1 }
+    FNR > 1 && $4 == "01" && ($10 in set) {
+        split($3, r, ":")
+        if (r[2] == "01BB") { found = 1; exit }
+    }
+    END { exit found ? 0 : 1 }
+' /proc/net/tcp /proc/net/tcp6; then
+    touch /run/librespot-cloud-armed
+    exit 0
+fi
+
+if [ -f /run/librespot-cloud-armed ]; then
+    echo "probe: cloud session gone (no dealer websocket)"
+    exit 1
+fi
+exit 0

--- a/librespot/start.sh
+++ b/librespot/start.sh
@@ -29,20 +29,20 @@ librespot \
 LIBRESPOT_PID=$!
 
 # librespot can wedge with its process alive but its Spotify session dead, in
-# which case it never recovers on its own. The zeroconf HTTP endpoint doubles
-# as a liveness probe: on sustained failure, kill librespot so the container
-# exits and docker's restart policy brings it back fresh. TERM first, KILL
-# after a grace period because a wedged process may never handle TERM.
+# which case it never recovers on its own. /probe.sh checks both the zeroconf
+# endpoint and the cloud session: on sustained failure, kill librespot so the
+# container exits and docker's restart policy brings it back fresh. TERM
+# first, KILL after a grace period because a wedged process may never handle
+# TERM.
 (
     fails=0
     while kill -0 "$LIBRESPOT_PID" 2>/dev/null; do
         sleep "$WATCHDOG_INTERVAL"
-        if curl --connect-timeout 5 --max-time 8 --silent --fail \
-                "http://localhost:${ZEROCONF_PORT}/?action=getInfo" >/dev/null; then
+        if /probe.sh; then
             fails=0
         else
             fails=$((fails + 1))
-            echo "watchdog: getInfo probe failed (${fails}/${WATCHDOG_FAILURES})"
+            echo "watchdog: probe failed (${fails}/${WATCHDOG_FAILURES})"
             if [ "$fails" -ge "$WATCHDOG_FAILURES" ]; then
                 echo "watchdog: librespot unresponsive, terminating"
                 kill -TERM "$LIBRESPOT_PID" 2>/dev/null


### PR DESCRIPTION
## The incident (2026-07-10)

librespot wedged again at 04:34: `Websocket peer does not respond.` then total silence for 6+ hours. The container stayed "healthy" and the watchdog never fired — the zeroconf HTTP endpoint kept answering, which is all the v1 probe checked. This was the known blind spot from #61.

Live socket inspection of the wedged process captured the fingerprint:
- AP connection (remote port **4070**): still ESTABLISHED
- Dealer websocket (remote port **443** — the channel carrying Spotify Connect presence/commands): **gone**

A healthy session keeps the dealer websocket open at all times.

## The fix

Shared `probe.sh` used by both the in-container watchdog and the Docker HEALTHCHECK:

1. getInfo on the zeroconf endpoint (as before)
2. require an ESTABLISHED librespot socket with remote port 443, matched by socket inode (host networking, so `/proc/net/tcp*` must be filtered to the process)

The cloud check **self-arms** the first time a dealer connection is seen (marker in `/run`, resets per container start), so credential-less deployments idling without a session are never restart-looped. `WATCHDOG_CLOUD_CHECK=off` disables it.

## Verification

- Probe run against the **actually wedged** instance's socket state: fail (no 443)
- Probe run inside the live healthy container: pass + self-armed
- Healthcheck now also flips unhealthy on a cloud wedge, so Portainer/monitoring see it

After merge: pull-and-redeploy the `mopidysnapserver` stack (only `spotify-connect` recreates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)